### PR TITLE
corrected apache 2.0 link

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ Note: After the secret is updated, you cannot use a state image obtained using t
 
 ## License
 
-[Apache 2.0](https://github.com/ibm-hyper-protect/secure-build-cli/blob/main/LICENSE)
+[Apache 2.0](https://github.com/ibm-hyper-protect/service-build-cli/blob/main/LICENSE)
 
 ## Contributor License Agreement (CLA)
 


### PR DESCRIPTION
Changed (https://github.com/ibm-hyper-protect/secure-build-cli/blob/main/LICENSE)
to 
https://github.com/ibm-hyper-protect/service-build-cli/blob/main/LICENSE