### PR TITLE
change the volume value from test to hspb

### DIFF
--- a/SBS-VPC.md
+++ b/SBS-VPC.md
@@ -209,7 +209,7 @@ env: |
       ingestionKey: **********************************
       port: 14XX
   volumes:
-    test:
+    hpsb:
       seed: "testing"
   env:
     CLIENT_CRT: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR3RENDQXFpZ0F3SUJBZ0lFQmR6U1VEQU5CZ2txaGtpRzl3MEJBUXNGQURCbU1Rc3dDUVlEVlFRR0V3SlYKVXpFTE1Ba0dBMVVFQ0F3Q1Rsa3hEekFOQmdOVkJB.....................


### PR DESCRIPTION
1 . We have made changes to the volume name in the workload . It is now `hpsb`. We need to change documentation regarding the `env` section and make volume name as `hpsb` there as well
https://github.com/ibm-hyper-protect/secure-build-cli/blob/master/SBS-VPC.md#an-example-of-the-env-section-of-the-contract


The changes will due on Apr 21st