### PR TITLE
fix: update python dependencies for x86 and s390x systems

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests
-pyOpenSSL
-python-gnupg
+pyOpenSSL==26.0.0
+python-gnupg==0.5.6

--- a/requirements390x.txt
+++ b/requirements390x.txt
@@ -1,3 +1,2 @@
-pip3 install requests
-apt-get install -y python3-openssl
-pip3 install python-gnupg
+apt-get update
+apt-get install -y python3-requests python3-openssl python3-gnupg


### PR DESCRIPTION
- Pin version numbers for x86 packages.
- Change pip commands to apt-get in requirements390x.txt.